### PR TITLE
Course/chat memory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  postgres:
+    container_name: postgres
+    image: postgres:17.5
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 251101
+    ports:
+      - "5433:5432"

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,19 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-chat-memory-repository-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,16 @@ server:
 spring:
   application:
     name: Spring-Ai
+  datasource:
+    url: jdbc:postgresql://localhost:5433/spring_ai
+    username: postgres
+    password: 251101
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
   ai:
     openai:
       api-key: ${GEMINI_KEY}
@@ -11,3 +21,11 @@ spring:
         completions-path: /v1beta/openai/chat/completions
         options:
           model: gemini-2.0-flash
+
+    chat:
+      memory:
+        repository:
+          jdbc:
+            initialize-schema: always
+
+


### PR DESCRIPTION
This pull request introduces PostgreSQL as a persistent chat memory backend for the AI chat service, enabling conversation history to be stored and retrieved across sessions. The changes include Docker-based setup for PostgreSQL, Spring Boot configuration for database connectivity, new dependencies for JDBC-based chat memory, and updates to the `ChatService` to use the new memory repository.

**Infrastructure and Configuration**

* Added a `postgres` service to `docker-compose.yml` to provide a local PostgreSQL instance for development and testing.
* Configured Spring Boot datasource and JPA settings in `application.yml` to connect to the PostgreSQL instance, and enabled automatic schema initialization for the chat memory JDBC repository. [[1]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR6-R15) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR24-R31)

**Dependency Management**

* Added dependencies to `pom.xml` for the PostgreSQL JDBC driver, Spring Data JPA, and Spring AI's JDBC chat memory repository starter.

**Chat Memory Integration**

* Updated `ChatService` to inject and use `JdbcChatMemoryRepository`, configure a `MessageWindowChatMemory` with a maximum of 30 messages, and set up the `ChatClient` to use chat memory advisors for conversation context. [[1]](diffhunk://#diff-d0d7710f8dc223a6dac143b5a348d2790020943be14c809e439f2dac5d4efa95R8-R11) [[2]](diffhunk://#diff-d0d7710f8dc223a6dac143b5a348d2790020943be14c809e439f2dac5d4efa95R28-R45)
* Modified the `chat` method in `ChatService` to associate each chat request with a specific conversation ID, ensuring messages are persisted and retrieved from the correct conversation history.