### PR TITLE
Main

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  postgres:
+    container_name: postgres
+    image: postgres:17.5
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: 251101
+    ports:
+      - "5433:5432"

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,19 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-chat-memory-repository-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/com/vti/springai/controller/ChatController.java
+++ b/src/main/java/com/vti/springai/controller/ChatController.java
@@ -1,12 +1,17 @@
 package com.vti.springai.controller;
 
+import com.vti.springai.dto.BillItem;
 import com.vti.springai.dto.ChatRequest;
+import com.vti.springai.dto.ExpenseInfo;
+import com.vti.springai.dto.FilmInfo;
 import com.vti.springai.service.ChatService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 public class ChatController {
@@ -17,13 +22,13 @@ public class ChatController {
     }
 
     @PostMapping("/chat")
-    String chat(@RequestBody ChatRequest request) {
+    ExpenseInfo chat(@RequestBody ChatRequest request) {
         return chatService.chat(request);
     }
 
     @PostMapping("/chat-with-image")
-    String chatWithImage(@RequestParam("file")MultipartFile file,
-                         @RequestParam("message") String message) {
+    List<BillItem> chatWithImage(@RequestParam("file")MultipartFile file,
+                                 @RequestParam("message") String message) {
         return chatService.chatWithImage(file, message);
     }
 }

--- a/src/main/java/com/vti/springai/dto/BillItem.java
+++ b/src/main/java/com/vti/springai/dto/BillItem.java
@@ -1,0 +1,10 @@
+package com.vti.springai.dto;
+
+public record BillItem(
+        String itemName,
+        String unit,
+        Integer quantity,
+        Double price,
+        Double subTotal
+) {
+}

--- a/src/main/java/com/vti/springai/dto/ExpenseInfo.java
+++ b/src/main/java/com/vti/springai/dto/ExpenseInfo.java
@@ -1,0 +1,8 @@
+package com.vti.springai.dto;
+// dùng để lưu thông tin chi tiêu
+public record ExpenseInfo(
+        String category,
+        String itemName,
+        Double amount
+) {
+}

--- a/src/main/java/com/vti/springai/dto/FilmInfo.java
+++ b/src/main/java/com/vti/springai/dto/FilmInfo.java
@@ -1,0 +1,8 @@
+package com.vti.springai.dto;
+
+public record FilmInfo(
+        String name,
+        String description,
+        String year
+) {
+}

--- a/src/main/java/com/vti/springai/service/ChatService.java
+++ b/src/main/java/com/vti/springai/service/ChatService.java
@@ -1,16 +1,21 @@
 package com.vti.springai.service;
 
+import com.vti.springai.dto.BillItem;
 import com.vti.springai.dto.ChatRequest;
+import com.vti.springai.dto.ExpenseInfo;
+import com.vti.springai.dto.FilmInfo;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -21,7 +26,7 @@ public class ChatService {
         chatClient = builder.build();
     }
 
-    public String chat(ChatRequest request) {
+    public ExpenseInfo chat(ChatRequest request) {
         SystemMessage systemMessage = new SystemMessage("""
                 You are VTI.AI
                 You should response with a formal voice
@@ -34,10 +39,10 @@ public class ChatService {
         return chatClient
                 .prompt(prompt)
                 .call()
-                .content();
+                .entity(ExpenseInfo.class);
     }
 
-    public String chatWithImage(MultipartFile file, String message) {
+    public List<BillItem> chatWithImage(MultipartFile file, String message) {
         Media media = Media.builder()
                 .mimeType(MimeTypeUtils.parseMimeType(Objects.requireNonNull(file.getContentType())))
                 .data(file.getResource())
@@ -54,6 +59,7 @@ public class ChatService {
                     -> promptUserSpec.media(media)
                     .text(message))
                 .call()
-                .content();
+                .entity(new ParameterizedTypeReference<List<BillItem>>() {
+                });
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,16 @@ server:
 spring:
   application:
     name: Spring-Ai
+  datasource:
+    url: jdbc:postgresql://localhost:5433/spring_ai
+    username: postgres
+    password: 251101
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
   ai:
     openai:
       api-key: ${GEMINI_KEY}
@@ -11,3 +21,11 @@ spring:
         completions-path: /v1beta/openai/chat/completions
         options:
           model: gemini-2.0-flash
+
+    chat:
+      memory:
+        repository:
+          jdbc:
+            initialize-schema: always
+
+


### PR DESCRIPTION
This pull request introduces PostgreSQL integration and enhances the chat functionality to support structured data exchange. It adds a PostgreSQL service for local development, updates dependencies to support JDBC-based chat memory, and refactors the chat endpoints and service logic to return typed DTOs instead of plain strings.

**Database Integration and Configuration**
* Added a `postgres` service to `docker-compose.yml` for local development, and configured Spring Boot to connect to PostgreSQL with proper JPA and Hibernate settings in `application.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R10) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR6-R15)
* Updated `pom.xml` to include dependencies for PostgreSQL, Spring Data JPA, and Spring AI JDBC chat memory repository.

**Chat Memory and Service Refactoring**
* Refactored `ChatService` to use `JdbcChatMemoryRepository` for persistent chat memory, and updated the chat logic to support conversation context.
* Changed the return types of chat endpoints in `ChatController` and `ChatService` to use structured DTOs (`ExpenseInfo` and `List<BillItem>`) instead of raw strings, improving type safety and clarity. [[1]](diffhunk://#diff-9e40794ae17365a2c7f2dcde0f99f695e0e0fccea3488d7699293c50aed1df37L20-R30) [[2]](diffhunk://#diff-d0d7710f8dc223a6dac143b5a348d2790020943be14c809e439f2dac5d4efa95R57-R64) [[3]](diffhunk://#diff-d0d7710f8dc223a6dac143b5a348d2790020943be14c809e439f2dac5d4efa95L57-R82)

**DTO Additions**
* Introduced new DTO records: `BillItem`, `ExpenseInfo`, and `FilmInfo` to represent structured data in chat responses. [[1]](diffhunk://#diff-6ed0139e5f587328a871573c22dd386a780498681a05f3d65d93ef4c186fae4dR1-R10) [[2]](diffhunk://#diff-7e614ccd01c3f6dca8136f46ccaa84e82d55c09e1500648acec79649664cc9b0R1-R8) [[3]](diffhunk://#diff-d6fe458a50d19d611580b5df8b9e0ebafdbc736070af78b921307cc93c0ff106R1-R8)

**Spring AI Configuration**
* Configured Spring AI chat memory to use JDBC repository and auto-initialize the schema in `application.yml`.

These changes collectively enable persistent, structured conversational AI interactions backed by a PostgreSQL database.